### PR TITLE
Refactor/#24

### DIFF
--- a/src/main/java/carrotTeam/carrot/domain/post/AwsConfig.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/AwsConfig.java
@@ -12,21 +12,21 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class AwsConfig {
 
-    @Value("${cloud.aws.credentials.accessKey}")
-    private String accessKey;
+  @Value("${cloud.aws.credentials.accessKey}")
+  private String accessKey;
 
-    @Value("${cloud.aws.credentials.secretKey}")
-    private String secretKey;
+  @Value("${cloud.aws.credentials.secretKey}")
+  private String secretKey;
 
-    @Value("${cloud.aws.region.static}")
-    private String region;
+  @Value("${cloud.aws.region.static}")
+  private String region;
 
-    @Bean
-    public AmazonS3 amazonS3() {
-        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-        return AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .build();
-    }
+  @Bean
+  public AmazonS3 amazonS3() {
+    AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    return AmazonS3ClientBuilder.standard()
+        .withRegion(region)
+        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+        .build();
+  }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package carrotTeam.carrot.domain.post.controller;
 
 import carrotTeam.carrot.domain.post.dto.PostInfo;
+import carrotTeam.carrot.domain.post.dto.PostInfoWithComment;
 import carrotTeam.carrot.domain.post.dto.PostRequest;
 import carrotTeam.carrot.domain.post.dto.PostUpdateRequest;
 import carrotTeam.carrot.domain.post.service.PostService;
@@ -74,7 +75,7 @@ public class PostController {
     }
 
     @GetMapping("/{id}")
-    public List<PostInfo> findByPostIdPost (
+    public PostInfoWithComment findByPostIdPost (
             @PathVariable Long id
     ) throws IOException {
         return service.findByPostId(id);

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -14,7 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +28,7 @@ public class PostController {
   public ResponseEntity<ResultResponse> createPost(
       @RequestPart(value = "files", required = true) List<MultipartFile> files,
       @RequestPart(value = "requestDto") PostRequest postRequest
-  ) throws Exception {
+  ) {
     List<String> address_list = new ArrayList<>();
 
     for (MultipartFile file : files) {
@@ -46,7 +45,7 @@ public class PostController {
   @PutMapping
   public ResponseEntity<ResultResponse> updatePost(
       @RequestBody PostUpdateRequest postUpdateRequest
-  ) throws IOException {
+  ) {
     PostInfo postInfo = service.updatePost(postUpdateRequest.getPost_id(),
         postUpdateRequest.getTitle(),
         postUpdateRequest.getContent());
@@ -56,7 +55,7 @@ public class PostController {
   @DeleteMapping("/{id}")
   public ResponseEntity<ResultResponse> deletePost(
       @PathVariable Long id
-  ) throws IOException {
+  ) {
     PostInfo postInfo = service.deletePost(id);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_POST_SUCCESS, postInfo));
   }
@@ -64,7 +63,7 @@ public class PostController {
   @GetMapping
   public ResponseEntity<ResultResponse> findTotalPost(
 
-  ) throws IOException {
+  ) {
     List<PostInfo> postList = service.findTotal();
     return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ALL_POST_SUCCESS, postList));
   }
@@ -72,7 +71,7 @@ public class PostController {
   @GetMapping("users/{id}")
   public ResponseEntity<ResultResponse> findByUserIdPost(
       @PathVariable Long id
-  ) throws IOException {
+  ) {
     List<PostInfo> postList = service.findByUserId(id);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_USER_POST_SUCCESS, postList));
   }
@@ -80,14 +79,14 @@ public class PostController {
   @GetMapping("/{id}")
   public PostInfoWithComment findByPostIdPost(
       @PathVariable Long id
-  ) throws IOException {
+  ) {
     return service.findByPostId(id);
   }
 
   @GetMapping("/word/{word}")
   public ResponseEntity<ResultResponse> findTotalRestaurant(
       @RequestParam String word
-  ) throws IOException {
+  ) {
     List<PostInfo> postList = service.findByWord(word);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_USER_POST_SUCCESS, postList));
   }

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -58,11 +58,18 @@ public class PostController {
         return service.findTotal();
     }
 
-    @GetMapping("/{id}")
-    public List<PostInfo> findTotalRestaurant (
+    @GetMapping("users/{id}")
+    public List<PostInfo> findByUserIdPost (
             @PathVariable Long id
     ) throws IOException {
-        return service.findById(id);
+        return service.findByUserId(id);
+    }
+
+    @GetMapping("/{id}")
+    public List<PostInfo> findByPostIdPost (
+            @PathVariable Long id
+    ) throws IOException {
+        return service.findByPostId(id);
     }
 
     @GetMapping("/word/{word}")

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -44,11 +44,19 @@ public class PostController {
 
   @PutMapping
   public ResponseEntity<ResultResponse> updatePost(
-      @RequestBody PostUpdateRequest postUpdateRequest
+      @RequestPart(value = "files", required = true) List<MultipartFile> files,
+      @RequestPart(value = "requestDto") PostUpdateRequest postUpdateRequest
   ) {
-    PostInfo postInfo = service.updatePost(postUpdateRequest.getPost_id(),
+    List<String> address_list = new ArrayList<>();
+
+    for (MultipartFile file : files) {
+      String picture_address = service.upload(file);
+      address_list.add(picture_address);
+    }
+
+    PostInfo postInfo = service.updatePost(postUpdateRequest.getUser_id(), postUpdateRequest.getPost_id(),
         postUpdateRequest.getTitle(),
-        postUpdateRequest.getContent());
+        postUpdateRequest.getContent(), address_list);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.UPDATE_POST_SUCCESS, postInfo));
   }
 

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -13,41 +13,51 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
+@RequestMapping("/api/posts")
 @RequiredArgsConstructor
 @RestController
 public class PostController {
 
     private final PostService service;
 
-
-    @PostMapping(value = "/upload", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public PostInfo uploadFile(@RequestPart(value = "images", required = false) MultipartFile multipartFile, @RequestPart(value = "request") PostRequest request) throws IOException {
         String picture_address = service.upload(multipartFile);
         return service.createPost(request, picture_address);
     }
 
-    @PutMapping(value = "/update")
-    public PostInfo updatePost(@RequestBody PostUpdateRequest request) throws IOException {
+    @PutMapping
+    public PostInfo updatePost (
+            @RequestBody PostUpdateRequest request
+    ) throws IOException {
         return service.updatePost(request.getPost_id(), request.getTitle(), request.getContent());
     }
 
-    @DeleteMapping(value = "/delete/{id}")
-    public PostInfo updatePost(@PathVariable Long id) throws IOException {
+    @DeleteMapping("/{id}")
+    public PostInfo updatePost (
+            @PathVariable Long id
+    ) throws IOException {
         return service.deletePost(id);
     }
 
-    @GetMapping(value = "/read")
-    public List<PostInfo> findTotalRestaurant () {
+    @GetMapping
+    public List<PostInfo> findTotalPost (
+
+    ) throws IOException {
         return service.findTotal();
     }
 
-    @GetMapping(value = "/read/{id}")
-    public List<PostInfo> findTotalRestaurant (@PathVariable Long id) {
+    @GetMapping("/{id}")
+    public List<PostInfo> findTotalRestaurant (
+            @PathVariable Long id
+    ) throws IOException {
         return service.findById(id);
     }
 
-    @GetMapping(value = "/read/word")
-    public List<PostInfo> findTotalRestaurant (@RequestParam String word) {
+    @GetMapping("/word/{word}")
+    public List<PostInfo> findTotalRestaurant (
+            @RequestParam String word
+    ) throws IOException {
         return service.findByWord(word);
     }
 

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -23,71 +23,73 @@ import java.util.List;
 @RestController
 public class PostController {
 
-    private final PostService service;
+  private final PostService service;
 
-    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
-    public ResponseEntity<ResultResponse> creatPost (
-            @RequestPart(value = "files", required=true) List<MultipartFile> files,
-            @RequestPart(value = "requestDto") PostRequest request
-    ) throws Exception {
-        List<String> address_list = new ArrayList<>();
+  @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<ResultResponse> creatPost(
+      @RequestPart(value = "files", required = true) List<MultipartFile> files,
+      @RequestPart(value = "requestDto") PostRequest request
+  ) throws Exception {
+    List<String> address_list = new ArrayList<>();
 
-        for(MultipartFile file : files) {
-            String picture_address = service.upload(file);
-            address_list.add(picture_address);
-        }
-
-        PostInfo postInfo = service.createPost(request.getUser_id(), request.getTitle(), request.getContent(), address_list);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.CREATE_POST_SUCCESS, postInfo));
+    for (MultipartFile file : files) {
+      String picture_address = service.upload(file);
+      address_list.add(picture_address);
     }
 
+    PostInfo postInfo = service.createPost(request.getUser_id(), request.getTitle(),
+        request.getContent(), address_list);
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.CREATE_POST_SUCCESS, postInfo));
+  }
 
-    @PutMapping
-    public ResponseEntity<ResultResponse> updatePost (
-            @RequestBody PostUpdateRequest request
-    ) throws IOException {
-        PostInfo postInfo = service.updatePost(request.getPost_id(), request.getTitle(), request.getContent());
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.UPDATE_POST_SUCCESS, postInfo));
-    }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<ResultResponse> deletePost (
-            @PathVariable Long id
-    ) throws IOException {
-        PostInfo postInfo = service.deletePost(id);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_POST_SUCCESS, postInfo));
-    }
+  @PutMapping
+  public ResponseEntity<ResultResponse> updatePost(
+      @RequestBody PostUpdateRequest request
+  ) throws IOException {
+    PostInfo postInfo = service.updatePost(request.getPost_id(), request.getTitle(),
+        request.getContent());
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.UPDATE_POST_SUCCESS, postInfo));
+  }
 
-    @GetMapping
-    public ResponseEntity<ResultResponse> findTotalPost (
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ResultResponse> deletePost(
+      @PathVariable Long id
+  ) throws IOException {
+    PostInfo postInfo = service.deletePost(id);
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_POST_SUCCESS, postInfo));
+  }
 
-    ) throws IOException {
-        List<PostInfo> postList = service.findTotal();
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ALL_POST_SUCCESS, postList));
-    }
+  @GetMapping
+  public ResponseEntity<ResultResponse> findTotalPost(
 
-    @GetMapping("users/{id}")
-    public ResponseEntity<ResultResponse> findByUserIdPost (
-            @PathVariable Long id
-    ) throws IOException {
-        List<PostInfo> postList = service.findByUserId(id);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_USER_POST_SUCCESS, postList));
-    }
+  ) throws IOException {
+    List<PostInfo> postList = service.findTotal();
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ALL_POST_SUCCESS, postList));
+  }
 
-    @GetMapping("/{id}")
-    public PostInfoWithComment findByPostIdPost (
-            @PathVariable Long id
-    ) throws IOException {
-        return service.findByPostId(id);
-    }
+  @GetMapping("users/{id}")
+  public ResponseEntity<ResultResponse> findByUserIdPost(
+      @PathVariable Long id
+  ) throws IOException {
+    List<PostInfo> postList = service.findByUserId(id);
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_USER_POST_SUCCESS, postList));
+  }
 
-    @GetMapping("/word/{word}")
-    public ResponseEntity<ResultResponse> findTotalRestaurant (
-            @RequestParam String word
-    ) throws IOException {
-        List<PostInfo> postList = service.findByWord(word);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_USER_POST_SUCCESS, postList));
-    }
+  @GetMapping("/{id}")
+  public PostInfoWithComment findByPostIdPost(
+      @PathVariable Long id
+  ) throws IOException {
+    return service.findByPostId(id);
+  }
+
+  @GetMapping("/word/{word}")
+  public ResponseEntity<ResultResponse> findTotalRestaurant(
+      @RequestParam String word
+  ) throws IOException {
+    List<PostInfo> postList = service.findByWord(word);
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_USER_POST_SUCCESS, postList));
+  }
 
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -26,9 +26,9 @@ public class PostController {
   private final PostService service;
 
   @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<ResultResponse> creatPost(
+  public ResponseEntity<ResultResponse> createPost(
       @RequestPart(value = "files", required = true) List<MultipartFile> files,
-      @RequestPart(value = "requestDto") PostRequest request
+      @RequestPart(value = "requestDto") PostRequest postRequest
   ) throws Exception {
     List<String> address_list = new ArrayList<>();
 
@@ -37,18 +37,19 @@ public class PostController {
       address_list.add(picture_address);
     }
 
-    PostInfo postInfo = service.createPost(request.getUser_id(), request.getTitle(),
-        request.getContent(), address_list);
+    PostInfo postInfo = service.createPost(postRequest.getUser_id(), postRequest.getTitle(),
+        postRequest.getContent(), address_list);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.CREATE_POST_SUCCESS, postInfo));
   }
 
 
   @PutMapping
   public ResponseEntity<ResultResponse> updatePost(
-      @RequestBody PostUpdateRequest request
+      @RequestBody PostUpdateRequest postUpdateRequest
   ) throws IOException {
-    PostInfo postInfo = service.updatePost(request.getPost_id(), request.getTitle(),
-        request.getContent());
+    PostInfo postInfo = service.updatePost(postUpdateRequest.getPost_id(),
+        postUpdateRequest.getTitle(),
+        postUpdateRequest.getContent());
     return ResponseEntity.ok(ResultResponse.of(ResultCode.UPDATE_POST_SUCCESS, postInfo));
   }
 

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequestMapping("/api/posts")
@@ -21,10 +22,20 @@ public class PostController {
     private final PostService service;
 
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
-    public PostInfo uploadFile(@RequestPart(value = "images", required = false) MultipartFile multipartFile, @RequestPart(value = "request") PostRequest request) throws IOException {
-        String picture_address = service.upload(multipartFile);
-        return service.createPost(request, picture_address);
+    public PostInfo creatPost (
+            @RequestPart(value = "files", required=true) List<MultipartFile> files,
+            @RequestPart(value = "requestDto") PostRequest request
+    ) throws Exception {
+        List<String> address_list = new ArrayList<>();
+
+        for(MultipartFile file : files) {
+            String picture_address = service.upload(file);
+            address_list.add(picture_address);
+        }
+
+        return service.createPost(request.getUser_id(), request.getTitle(), request.getContent(), address_list);
     }
+
 
     @PutMapping
     public PostInfo updatePost (

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -5,8 +5,11 @@ import carrotTeam.carrot.domain.post.dto.PostRequest;
 import carrotTeam.carrot.domain.post.dto.PostUpdateRequest;
 import carrotTeam.carrot.domain.post.service.PostService;
 
+import carrotTeam.carrot.global.result.ResultCode;
+import carrotTeam.carrot.global.result.ResultResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,7 +25,7 @@ public class PostController {
     private final PostService service;
 
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
-    public PostInfo creatPost (
+    public ResponseEntity<ResultResponse> creatPost (
             @RequestPart(value = "files", required=true) List<MultipartFile> files,
             @RequestPart(value = "requestDto") PostRequest request
     ) throws Exception {
@@ -33,36 +36,41 @@ public class PostController {
             address_list.add(picture_address);
         }
 
-        return service.createPost(request.getUser_id(), request.getTitle(), request.getContent(), address_list);
+        PostInfo postInfo = service.createPost(request.getUser_id(), request.getTitle(), request.getContent(), address_list);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.CREATE_POST_SUCCESS, postInfo));
     }
 
 
     @PutMapping
-    public PostInfo updatePost (
+    public ResponseEntity<ResultResponse> updatePost (
             @RequestBody PostUpdateRequest request
     ) throws IOException {
-        return service.updatePost(request.getPost_id(), request.getTitle(), request.getContent());
+        PostInfo postInfo = service.updatePost(request.getPost_id(), request.getTitle(), request.getContent());
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.UPDATE_POST_SUCCESS, postInfo));
     }
 
     @DeleteMapping("/{id}")
-    public PostInfo updatePost (
+    public ResponseEntity<ResultResponse> deletePost (
             @PathVariable Long id
     ) throws IOException {
-        return service.deletePost(id);
+        PostInfo postInfo = service.deletePost(id);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_POST_SUCCESS, postInfo));
     }
 
     @GetMapping
-    public List<PostInfo> findTotalPost (
+    public ResponseEntity<ResultResponse> findTotalPost (
 
     ) throws IOException {
-        return service.findTotal();
+        List<PostInfo> postList = service.findTotal();
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ALL_POST_SUCCESS, postList));
     }
 
     @GetMapping("users/{id}")
-    public List<PostInfo> findByUserIdPost (
+    public ResponseEntity<ResultResponse> findByUserIdPost (
             @PathVariable Long id
     ) throws IOException {
-        return service.findByUserId(id);
+        List<PostInfo> postList = service.findByUserId(id);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_USER_POST_SUCCESS, postList));
     }
 
     @GetMapping("/{id}")
@@ -73,10 +81,11 @@ public class PostController {
     }
 
     @GetMapping("/word/{word}")
-    public List<PostInfo> findTotalRestaurant (
+    public ResponseEntity<ResultResponse> findTotalRestaurant (
             @RequestParam String word
     ) throws IOException {
-        return service.findByWord(word);
+        List<PostInfo> postList = service.findByWord(word);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_USER_POST_SUCCESS, postList));
     }
 
 

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -24,14 +25,15 @@ public class Post extends BaseEntity {
     private String content;
 
     @Column(name = "picture_address", nullable = false, length = 2000)
-    private String picture_address;
+    @ElementCollection
+    private List<String> picture_address;
 
     @ManyToOne(targetEntity = User.class)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
-    public Post(User user, String title, String content, String picture_address) {
+    public Post(User user, String title, String content, List<String> picture_address) {
         this.user = user;
         this.title = title;
         this.content = content;

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -15,39 +15,41 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class Post extends BaseEntity {
-    @Id
-    @GeneratedValue
-    @Column(name = "post_id", nullable = false)
-    private Long id;
 
-    @Column(name = "title", nullable = false, length = 100)
-    private String title;
+  @Id
+  @GeneratedValue
+  @Column(name = "post_id", nullable = false)
+  private Long id;
 
-    @Column(name = "content", nullable = false, length = 500)
-    private String content;
+  @Column(name = "title", nullable = false, length = 100)
+  private String title;
 
-    @Column(name = "picture_address", nullable = false, length = 2000)
-    @ElementCollection
-    private List<String> picture_address;
+  @Column(name = "content", nullable = false, length = 500)
+  private String content;
 
-    @ManyToOne(targetEntity = User.class, fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+  @Column(name = "picture_address", nullable = false, length = 2000)
+  @ElementCollection
+  private List<String> picture_address;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<Comment> comment = new ArrayList<>();
+  @ManyToOne(targetEntity = User.class, fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-    @Builder
-    public Post(User user, String title, String content, List<String> picture_address, List<Comment> comment) {
-        this.user = user;
-        this.title = title;
-        this.content = content;
-        this.picture_address = picture_address;
-        this.comment = comment;
-    }
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+  private List<Comment> comment = new ArrayList<>();
 
-    public void update (String title, String content) {
-        this.title = title;
-        this.content = content;
-    }
+  @Builder
+  public Post(User user, String title, String content, List<String> picture_address,
+      List<Comment> comment) {
+    this.user = user;
+    this.title = title;
+    this.content = content;
+    this.picture_address = picture_address;
+    this.comment = comment;
+  }
+
+  public void update(String title, String content) {
+    this.title = title;
+    this.content = content;
+  }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -28,7 +28,7 @@ public class Post extends BaseEntity {
     @ElementCollection
     private List<String> picture_address;
 
-    @ManyToOne(targetEntity = User.class)
+    @ManyToOne(targetEntity = User.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class Post extends BaseEntity {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "post_id", nullable = false)
   private Long id;
 
@@ -48,8 +48,9 @@ public class Post extends BaseEntity {
     this.comment = comment;
   }
 
-  public void update(String title, String content) {
+  public void update(String title, String content, List<String> picture_address) {
     this.title = title;
     this.content = content;
+    this.picture_address = picture_address;
   }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -1,5 +1,6 @@
 package carrotTeam.carrot.domain.post.domain.entity;
 
+import carrotTeam.carrot.domain.comment.domain.entity.Comment;
 import carrotTeam.carrot.domain.user.domain.entity.User;
 import carrotTeam.carrot.global.common.BaseEntity;
 import lombok.Builder;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -32,12 +34,16 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Comment> comment = new ArrayList<>();
+
     @Builder
-    public Post(User user, String title, String content, List<String> picture_address) {
+    public Post(User user, String title, String content, List<String> picture_address, List<Comment> comment) {
         this.user = user;
         this.title = title;
         this.content = content;
         this.picture_address = picture_address;
+        this.comment = comment;
     }
 
     public void update (String title, String content) {

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/repository/PostRepository.java
@@ -16,7 +16,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByUserIdAndIsActive(Long id, Boolean isActive);
 
     @Query(value = "SELECT p FROM Post p WHERE p.id = :id AND p.isActive = :isActive")
-    List<Post> findByPostIdAndIsActive(Long id, Boolean isActive);
+    Post findByPostIdAndIsActive(Long id, Boolean isActive);
 
     @Query(value = "SELECT p FROM Post p WHERE (p.title LIKE %:word% OR p.content LIKE %:word%) AND p.isActive = :isActive")
     List<Post> findByWordAndIsActive(String word, Boolean isActive);

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/repository/PostRepository.java
@@ -13,7 +13,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByIsActive(Boolean isActive);
 
     @Query(value = "SELECT p FROM Post p WHERE p.user.id = :id AND p.isActive = :isActive")
-    List<Post> findByIdAndIsActive(Long id, Boolean isActive);
+    List<Post> findByUserIdAndIsActive(Long id, Boolean isActive);
+
+    @Query(value = "SELECT p FROM Post p WHERE p.id = :id AND p.isActive = :isActive")
+    List<Post> findByPostIdAndIsActive(Long id, Boolean isActive);
 
     @Query(value = "SELECT p FROM Post p WHERE (p.title LIKE %:word% OR p.content LIKE %:word%) AND p.isActive = :isActive")
     List<Post> findByWordAndIsActive(String word, Boolean isActive);

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/repository/PostRepository.java
@@ -12,12 +12,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
   List<Post> findAllByIsActive(Boolean isActive);
 
-  @Query(value = "SELECT p FROM Post p WHERE p.user.id = :id AND p.isActive = :isActive")
-  List<Post> findByUserIdAndIsActive(Long id, Boolean isActive);
+  @Query(value = "SELECT p FROM Post p WHERE p.user.id = :id AND p.isActive = true")
+  List<Post> findByUserIdAndIsActive(Long id);
 
-  @Query(value = "SELECT p FROM Post p WHERE p.id = :id AND p.isActive = :isActive")
-  Post findByPostIdAndIsActive(Long id, Boolean isActive);
+  @Query(value = "SELECT p FROM Post p WHERE p.id = :id AND p.isActive = true")
+  Post findByPostIdAndIsActive(Long id);
 
-  @Query(value = "SELECT p FROM Post p WHERE (p.title LIKE %:word% OR p.content LIKE %:word%) AND p.isActive = :isActive")
-  List<Post> findByWordAndIsActive(String word, Boolean isActive);
+  @Query(value = "SELECT p FROM Post p WHERE (p.title LIKE %:word% OR p.content LIKE %:word%) AND p.isActive = true")
+  List<Post> findByWordAndIsActive(String word);
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/repository/PostRepository.java
@@ -10,14 +10,14 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    List<Post> findAllByIsActive(Boolean isActive);
+  List<Post> findAllByIsActive(Boolean isActive);
 
-    @Query(value = "SELECT p FROM Post p WHERE p.user.id = :id AND p.isActive = :isActive")
-    List<Post> findByUserIdAndIsActive(Long id, Boolean isActive);
+  @Query(value = "SELECT p FROM Post p WHERE p.user.id = :id AND p.isActive = :isActive")
+  List<Post> findByUserIdAndIsActive(Long id, Boolean isActive);
 
-    @Query(value = "SELECT p FROM Post p WHERE p.id = :id AND p.isActive = :isActive")
-    Post findByPostIdAndIsActive(Long id, Boolean isActive);
+  @Query(value = "SELECT p FROM Post p WHERE p.id = :id AND p.isActive = :isActive")
+  Post findByPostIdAndIsActive(Long id, Boolean isActive);
 
-    @Query(value = "SELECT p FROM Post p WHERE (p.title LIKE %:word% OR p.content LIKE %:word%) AND p.isActive = :isActive")
-    List<Post> findByWordAndIsActive(String word, Boolean isActive);
+  @Query(value = "SELECT p FROM Post p WHERE (p.title LIKE %:word% OR p.content LIKE %:word%) AND p.isActive = :isActive")
+  List<Post> findByWordAndIsActive(String word, Boolean isActive);
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfo.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfo.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -16,7 +17,7 @@ public class PostInfo {
     private Long user_id;
     private String title;
     private String content;
-    private String picture_address;
+    private List<String> picture_address;
     private Boolean isActive;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfo.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfo.java
@@ -14,23 +14,24 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class PostInfo {
-    private Long user_id;
-    private String title;
-    private String content;
-    private List<String> picture_address;
-    private Boolean isActive;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
-    public static PostInfo of(Post entity) {
-        return PostInfo.builder()
-                .user_id(entity.getUser().getId())
-                .title(entity.getTitle())
-                .content(entity.getContent())
-                .picture_address(entity.getPicture_address())
-                .isActive(entity.getIsActive())
-                .createdAt(entity.getCreatedAt())
-                .updatedAt(entity.getUpdatedAt())
-                .build();
-    }
+  private Long user_id;
+  private String title;
+  private String content;
+  private List<String> picture_address;
+  private Boolean isActive;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static PostInfo of(Post entity) {
+    return PostInfo.builder()
+        .user_id(entity.getUser().getId())
+        .title(entity.getTitle())
+        .content(entity.getContent())
+        .picture_address(entity.getPicture_address())
+        .isActive(entity.getIsActive())
+        .createdAt(entity.getCreatedAt())
+        .updatedAt(entity.getUpdatedAt())
+        .build();
+  }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfoWithComment.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfoWithComment.java
@@ -1,0 +1,28 @@
+package carrotTeam.carrot.domain.post.dto;
+
+import carrotTeam.carrot.domain.comment.domain.entity.Comment;
+import carrotTeam.carrot.domain.post.domain.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostInfoWithComment {
+    private Long user_id;
+    private String title;
+    private String content;
+    private List<String> picture_address;
+    private Boolean isActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<String> comment;
+
+}
+

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfoWithComment.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfoWithComment.java
@@ -15,14 +15,15 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class PostInfoWithComment {
-    private Long user_id;
-    private String title;
-    private String content;
-    private List<String> picture_address;
-    private Boolean isActive;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-    private List<String> comment;
+
+  private Long user_id;
+  private String title;
+  private String content;
+  private List<String> picture_address;
+  private Boolean isActive;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private List<String> comment;
 
 }
 

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostRequest.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostRequest.java
@@ -13,12 +13,12 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class PostRequest {
 
-    @NotBlank(message = "회원은 공백일 수 없습니다")
-    private Long user_id;
+  @NotBlank(message = "회원은 공백일 수 없습니다")
+  private Long user_id;
 
-    @NotBlank(message = "제목은 공백일 수 없습니다")
-    private String title;
+  @NotBlank(message = "제목은 공백일 수 없습니다")
+  private String title;
 
-    @NotBlank(message = "내용은 공백일 수 없습니다")
-    private String content;
+  @NotBlank(message = "내용은 공백일 수 없습니다")
+  private String content;
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostUpdateRequest.java
@@ -13,15 +13,15 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class PostUpdateRequest {
 
-    @NotBlank(message = "회원은 공백일 수 없습니다")
-    private Long user_id;
+  @NotBlank(message = "회원은 공백일 수 없습니다")
+  private Long user_id;
 
-    @NotBlank(message = "수정 할 게시글은 공백일 수 없습니다")
-    private Long post_id;
+  @NotBlank(message = "수정 할 게시글은 공백일 수 없습니다")
+  private Long post_id;
 
-    @NotBlank(message = "제목은 공백일 수 없습니다")
-    private String title;
+  @NotBlank(message = "제목은 공백일 수 없습니다")
+  private String title;
 
-    @NotBlank(message = "내용은 공백일 수 없습니다")
-    private String content;
+  @NotBlank(message = "내용은 공백일 수 없습니다")
+  private String content;
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostUpdateRequest.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostUpdateRequest.java
@@ -18,6 +18,7 @@ public class PostUpdateRequest {
 
     @NotBlank(message = "수정 할 게시글은 공백일 수 없습니다")
     private Long post_id;
+
     @NotBlank(message = "제목은 공백일 수 없습니다")
     private String title;
 

--- a/src/main/java/carrotTeam/carrot/domain/post/exception/NotFoundPost.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/exception/NotFoundPost.java
@@ -5,7 +5,7 @@ import carrotTeam.carrot.global.error.exception.BusinessException;
 
 public class NotFoundPost extends BusinessException {
 
-    public NotFoundPost() {
-        super(ErrorCode.POST_NOT_FOUND);
-    }
+  public NotFoundPost() {
+    super(ErrorCode.POST_NOT_FOUND);
+  }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/exception/NotUpdatePost.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/exception/NotUpdatePost.java
@@ -4,6 +4,7 @@ import carrotTeam.carrot.global.error.ErrorCode;
 import carrotTeam.carrot.global.error.exception.BusinessException;
 
 public class NotUpdatePost extends BusinessException {
+
   public NotUpdatePost() {
     super(ErrorCode.POST_NOT_UPDATE);
   }

--- a/src/main/java/carrotTeam/carrot/domain/post/exception/NotUpdatePost.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/exception/NotUpdatePost.java
@@ -1,0 +1,11 @@
+package carrotTeam.carrot.domain.post.exception;
+
+import carrotTeam.carrot.global.error.ErrorCode;
+import carrotTeam.carrot.global.error.exception.BusinessException;
+
+public class NotUpdatePost extends BusinessException {
+  public NotUpdatePost() {
+    super(ErrorCode.POST_NOT_UPDATE);
+  }
+
+}

--- a/src/main/java/carrotTeam/carrot/domain/post/exception/NotUploadPost.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/exception/NotUploadPost.java
@@ -1,0 +1,11 @@
+package carrotTeam.carrot.domain.post.exception;
+
+import carrotTeam.carrot.global.error.ErrorCode;
+import carrotTeam.carrot.global.error.exception.BusinessException;
+
+public class NotUploadPost extends BusinessException {
+
+  public NotUploadPost() {
+    super(ErrorCode.POST_NOT_UPLOAD);
+  }
+}

--- a/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
@@ -1,10 +1,14 @@
 package carrotTeam.carrot.domain.post.mapper;
 
+import carrotTeam.carrot.domain.comment.domain.entity.Comment;
 import carrotTeam.carrot.domain.post.domain.entity.Post;
 import carrotTeam.carrot.domain.post.dto.PostInfo;
+import carrotTeam.carrot.domain.post.dto.PostInfoWithComment;
 import carrotTeam.carrot.domain.post.dto.PostRequest;
 import carrotTeam.carrot.domain.user.dto.UserCreateRequest;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
 
 @Component
 public class PostMapper {
@@ -15,6 +19,32 @@ public class PostMapper {
                 .content(post.getContent())
                 .user_id(post.getUser().getId())
                 .picture_address(post.getPicture_address())
+                .build();
+    }
+
+    public PostInfoWithComment mapPostEntityToPostInfoWithComment(Post post){
+
+        ArrayList<String> three_comment_list = new ArrayList<>();
+        int count_comment = 0;
+
+        for (Comment c : post.getComment()) {
+            String id_content = "comment_user_id : " + c.getId() + ", comment_content : " + c.getContent();
+            three_comment_list.add(id_content);
+
+            count_comment++;
+
+            if (count_comment == 3) break;
+        }
+
+        return PostInfoWithComment.builder()
+                .user_id(post.getUser().getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .picture_address(post.getPicture_address())
+                .isActive(post.getIsActive())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .comment(three_comment_list)
                 .build();
     }
 

--- a/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
@@ -28,7 +28,8 @@ public class PostMapper {
     ArrayList<String> three_comment_list = new ArrayList<>();
     List<Comment> post_comment = post.getComment();
 
-    Collections.sort(post_comment, (Comment o1, Comment o2) -> -(o1.getCreatedAt().compareTo(o2.getCreatedAt())));
+    Collections.sort(post_comment,
+        (Comment o1, Comment o2) -> -(o1.getCreatedAt().compareTo(o2.getCreatedAt())));
 
     int count_comment = 0;
 

--- a/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
@@ -4,6 +4,7 @@ import carrotTeam.carrot.domain.comment.domain.entity.Comment;
 import carrotTeam.carrot.domain.post.domain.entity.Post;
 import carrotTeam.carrot.domain.post.dto.PostInfo;
 import carrotTeam.carrot.domain.post.dto.PostInfoWithComment;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -27,15 +28,7 @@ public class PostMapper {
     ArrayList<String> three_comment_list = new ArrayList<>();
     List<Comment> post_comment = post.getComment();
 
-    post_comment.sort(new Comparator<Comment>() {
-      @Override
-      public int compare(Comment o1, Comment o2) {
-        if (o1.getCreatedAt().compareTo(o2.getCreatedAt()) <= 0) {
-          return 1;
-        }
-        return -1;
-      }
-    });
+    Collections.sort(post_comment, (Comment o1, Comment o2) -> -(o1.getCreatedAt().compareTo(o2.getCreatedAt())));
 
     int count_comment = 0;
 

--- a/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
@@ -4,8 +4,8 @@ import carrotTeam.carrot.domain.comment.domain.entity.Comment;
 import carrotTeam.carrot.domain.post.domain.entity.Post;
 import carrotTeam.carrot.domain.post.dto.PostInfo;
 import carrotTeam.carrot.domain.post.dto.PostInfoWithComment;
-import carrotTeam.carrot.domain.post.dto.PostRequest;
-import carrotTeam.carrot.domain.user.dto.UserCreateRequest;
+import java.util.Comparator;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -25,9 +25,21 @@ public class PostMapper {
   public PostInfoWithComment mapPostEntityToPostInfoWithComment(Post post) {
 
     ArrayList<String> three_comment_list = new ArrayList<>();
+    List<Comment> post_comment = post.getComment();
+
+    post_comment.sort(new Comparator<Comment>() {
+      @Override
+      public int compare(Comment o1, Comment o2) {
+        if (o1.getCreatedAt().compareTo(o2.getCreatedAt()) <= 0) {
+          return 1;
+        }
+        return -1;
+      }
+    });
+
     int count_comment = 0;
 
-    for (Comment c : post.getComment()) {
+    for (Comment c : post_comment) {
       String id_content =
           "comment_user_id : " + c.getId() + ", comment_content : " + c.getContent();
       three_comment_list.add(id_content);

--- a/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
@@ -46,9 +46,9 @@ public class PostMapper {
 
       count_comment++;
 
-        if (count_comment == 3) {
-            break;
-        }
+      if (count_comment == 3) {
+        break;
+      }
     }
 
     return PostInfoWithComment.builder()

--- a/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/mapper/PostMapper.java
@@ -13,39 +13,42 @@ import java.util.ArrayList;
 @Component
 public class PostMapper {
 
-    public PostInfo mapPostEntityToPostInfo(Post post){
-        return PostInfo.builder()
-                .title(post.getTitle())
-                .content(post.getContent())
-                .user_id(post.getUser().getId())
-                .picture_address(post.getPicture_address())
-                .build();
-    }
+  public PostInfo mapPostEntityToPostInfo(Post post) {
+    return PostInfo.builder()
+        .title(post.getTitle())
+        .content(post.getContent())
+        .user_id(post.getUser().getId())
+        .picture_address(post.getPicture_address())
+        .build();
+  }
 
-    public PostInfoWithComment mapPostEntityToPostInfoWithComment(Post post){
+  public PostInfoWithComment mapPostEntityToPostInfoWithComment(Post post) {
 
-        ArrayList<String> three_comment_list = new ArrayList<>();
-        int count_comment = 0;
+    ArrayList<String> three_comment_list = new ArrayList<>();
+    int count_comment = 0;
 
-        for (Comment c : post.getComment()) {
-            String id_content = "comment_user_id : " + c.getId() + ", comment_content : " + c.getContent();
-            three_comment_list.add(id_content);
+    for (Comment c : post.getComment()) {
+      String id_content =
+          "comment_user_id : " + c.getId() + ", comment_content : " + c.getContent();
+      three_comment_list.add(id_content);
 
-            count_comment++;
+      count_comment++;
 
-            if (count_comment == 3) break;
+        if (count_comment == 3) {
+            break;
         }
-
-        return PostInfoWithComment.builder()
-                .user_id(post.getUser().getId())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .picture_address(post.getPicture_address())
-                .isActive(post.getIsActive())
-                .createdAt(post.getCreatedAt())
-                .updatedAt(post.getUpdatedAt())
-                .comment(three_comment_list)
-                .build();
     }
+
+    return PostInfoWithComment.builder()
+        .user_id(post.getUser().getId())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .picture_address(post.getPicture_address())
+        .isActive(post.getIsActive())
+        .createdAt(post.getCreatedAt())
+        .updatedAt(post.getUpdatedAt())
+        .comment(three_comment_list)
+        .build();
+  }
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -46,14 +46,14 @@ public class PostService {
         // getUrl 메소드를 통해서 S3에 업로드된 사진 URL을 가져오는 방식
         return amazonS3.getUrl(bucket, s3FileName).toString();
     }
-// 클린코드
-    public PostInfo createPost(PostRequest request, String picture_address) {
-        User user = userRepository.findById(request.getUser_id()).orElseThrow(null);
+
+    public PostInfo createPost(Long user_id, String title, String content, List<String> address_list) {
+        User user = userRepository.findById(user_id).orElseThrow(null);
         Post post = Post.builder()
-                .title(request.getTitle())
-                .content(request.getContent())
+                .title(title)
+                .content(content)
                 .user(user)
-                .picture_address(picture_address)
+                .picture_address(address_list)
                 .build();
         postRepository.save(post);
         return postMapper.mapPostEntityToPostInfo(post);

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import carrotTeam.carrot.domain.post.domain.repository.PostRepository;
 import carrotTeam.carrot.domain.post.dto.PostInfo;
 import carrotTeam.carrot.domain.post.dto.PostInfoWithComment;
 import carrotTeam.carrot.domain.post.exception.NotFoundPost;
+import carrotTeam.carrot.domain.post.exception.NotUpdatePost;
 import carrotTeam.carrot.domain.post.exception.NotUploadPost;
 import carrotTeam.carrot.domain.post.mapper.PostMapper;
 import carrotTeam.carrot.domain.user.domain.entity.User;
@@ -79,9 +80,15 @@ public class PostService {
     return postMapper.mapPostEntityToPostInfo(post);
   }
 
-  public PostInfo updatePost(Long id, String title, String content) {
-    Post post = postRepository.findById(id).orElseThrow(NotFoundPost::new);
-    post.update(title, content);
+  public PostInfo updatePost(Long user_id, Long post_id, String title, String content, List<String> address_list) {
+
+    Post post = postRepository.findById(post_id).orElseThrow(NotFoundPost::new);
+
+    if (post.getUser().getId() != user_id) {
+      throw new NotUpdatePost();
+    }
+
+    post.update(title, content, address_list);
     postRepository.save(post);
     return postMapper.mapPostEntityToPostInfo(post);
   }
@@ -91,6 +98,11 @@ public class PostService {
     ArrayList<Long> comment_list = new ArrayList<>();
     // post 지우기
     Post post = postRepository.findById(id).orElseThrow(NotFoundPost::new);
+
+    if (post.getUser().getId() != id) {
+      throw new NotUpdatePost();
+    }
+
     if (!post.getIsActive()) {
       throw new NotFoundPost();
     }

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import carrotTeam.carrot.domain.post.domain.repository.PostRepository;
 import carrotTeam.carrot.domain.post.dto.PostInfo;
 import carrotTeam.carrot.domain.post.dto.PostInfoWithComment;
 import carrotTeam.carrot.domain.post.exception.NotFoundPost;
+import carrotTeam.carrot.domain.post.exception.NotUploadPost;
 import carrotTeam.carrot.domain.post.mapper.PostMapper;
 import carrotTeam.carrot.domain.user.domain.entity.User;
 import carrotTeam.carrot.domain.user.domain.repositorty.UserRepository;
@@ -40,16 +41,21 @@ public class PostService {
 
   private final AmazonS3 amazonS3;
 
-  public String upload(MultipartFile multipartFile) throws IOException {
+  public String upload(MultipartFile multipartFile)  {
     // 파일 이름 중복 X -> UUID 로 생성한 랜덤 값에 파일이름 연결
     String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
 
     // Spring Server 에서 S3로 파일을 업로드 -> 이때 피일 사이즈를 ContentLength 로 S3 알려주기 위해 ObjectMetadata 사용
     ObjectMetadata objMeta = new ObjectMetadata();
-    objMeta.setContentLength(multipartFile.getInputStream().available());
 
-    // S3 API 메소드인 putObject 사용하여 파일 Stream 을 열어서 S3에 파일을 업로드
-    amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
+    try {
+      // 업로드 사이즈를 넘을 경우 오류 발생
+      objMeta.setContentLength(multipartFile.getInputStream().available());
+      // S3 API 메소드인 putObject 사용하여 파일 Stream 을 열어서 S3에 파일을 업로드
+      amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
+    } catch (IOException e) {
+      throw  new NotUploadPost();
+    }
 
     // getUrl 메소드를 통해서 S3에 업로드된 사진 URL을 가져오는 방식
     return amazonS3.getUrl(bucket, s3FileName).toString();

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -26,93 +26,95 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class PostService {
-    private final PostRepository postRepository;
-    private final UserRepository userRepository;
 
-    private final PostMapper postMapper;
+  private final PostRepository postRepository;
+  private final UserRepository userRepository;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+  private final PostMapper postMapper;
 
-    private final AmazonS3 amazonS3;
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
 
-    public String upload(MultipartFile multipartFile) throws IOException {
-        // 파일 이름 중복 X -> UUID 로 생성한 랜덤 값에 파일이름 연결
-        String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
+  private final AmazonS3 amazonS3;
 
-        // Spring Server 에서 S3로 파일을 업로드 -> 이때 피일 사이즈를 ContentLength 로 S3 알려주기 위해 ObjectMetadata 사용
-        ObjectMetadata objMeta = new ObjectMetadata();
-        objMeta.setContentLength(multipartFile.getInputStream().available());
+  public String upload(MultipartFile multipartFile) throws IOException {
+    // 파일 이름 중복 X -> UUID 로 생성한 랜덤 값에 파일이름 연결
+    String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
 
-        // S3 API 메소드인 putObject 사용하여 파일 Stream 을 열어서 S3에 파일을 업로드
-        amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
+    // Spring Server 에서 S3로 파일을 업로드 -> 이때 피일 사이즈를 ContentLength 로 S3 알려주기 위해 ObjectMetadata 사용
+    ObjectMetadata objMeta = new ObjectMetadata();
+    objMeta.setContentLength(multipartFile.getInputStream().available());
 
-        // getUrl 메소드를 통해서 S3에 업로드된 사진 URL을 가져오는 방식
-        return amazonS3.getUrl(bucket, s3FileName).toString();
+    // S3 API 메소드인 putObject 사용하여 파일 Stream 을 열어서 S3에 파일을 업로드
+    amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
+
+    // getUrl 메소드를 통해서 S3에 업로드된 사진 URL을 가져오는 방식
+    return amazonS3.getUrl(bucket, s3FileName).toString();
+  }
+
+  public PostInfo createPost(Long user_id, String title, String content,
+      List<String> address_list) {
+
+    if (!userRepository.existsById(user_id)) {
+      throw new NotFoundUser();
     }
 
-    public PostInfo createPost(Long user_id, String title, String content, List<String> address_list) {
+    User user = userRepository.findById(user_id).get();
+    Post post = Post.builder()
+        .title(title)
+        .content(content)
+        .user(user)
+        .picture_address(address_list)
+        .build();
+    postRepository.save(post);
+    return postMapper.mapPostEntityToPostInfo(post);
+  }
 
-        if(!userRepository.existsById(user_id)) {
-            throw new NotFoundUser();
-        }
+  public PostInfo updatePost(Long id, String title, String content) {
+    Post post = postRepository.findById(id).orElseThrow(NotFoundPost::new);
+    post.update(title, content);
+    postRepository.save(post);
+    return postMapper.mapPostEntityToPostInfo(post);
+  }
 
-        User user = userRepository.findById(user_id).get();
-        Post post = Post.builder()
-                .title(title)
-                .content(content)
-                .user(user)
-                .picture_address(address_list)
-                .build();
-        postRepository.save(post);
-        return postMapper.mapPostEntityToPostInfo(post);
+  @Transactional
+  public PostInfo deletePost(Long id) {
+    Post post = postRepository.findById(id).orElseThrow(NotFoundPost::new);
+    if (!post.getIsActive()) {
+      throw new NotFoundPost();
+    }
+    post.delete();
+    postRepository.save(post);
+    return postMapper.mapPostEntityToPostInfo(post);
+  }
+
+  public List<PostInfo> findTotal() {
+    return postRepository.findAllByIsActive(true).stream()
+        .map(PostInfo::of)
+        .collect(Collectors.toList());
+  }
+
+  public List<PostInfo> findByUserId(Long user_id) {
+
+    if (!userRepository.existsById(user_id)) {
+      throw new NotFoundUser();
     }
 
-    public PostInfo updatePost(Long id, String title, String content) {
-        Post post = postRepository.findById(id).orElseThrow(NotFoundPost::new);
-        post.update(title, content);
-        postRepository.save(post);
-        return postMapper.mapPostEntityToPostInfo(post);
-    }
+    return postRepository.findByUserIdAndIsActive(user_id, true).stream()
+        .map(PostInfo::of)
+        .collect(Collectors.toList());
+  }
 
-    @Transactional
-    public PostInfo deletePost(Long id) {
-        Post post = postRepository.findById(id).orElseThrow(NotFoundPost::new);
-        if(!post.getIsActive()){
-            throw new NotFoundPost();
-        }
-        post.delete();
-        postRepository.save(post);
-        return postMapper.mapPostEntityToPostInfo(post);
-    }
+  public PostInfoWithComment findByPostId(Long id) {
+    Post post = postRepository.findByPostIdAndIsActive(id, true);
+    return postMapper.mapPostEntityToPostInfoWithComment(post);
 
-    public List<PostInfo> findTotal() {
-        return postRepository.findAllByIsActive(true).stream()
-                .map(PostInfo::of)
-                .collect(Collectors.toList());
-    }
+  }
 
-    public List<PostInfo> findByUserId(Long user_id) {
-
-        if(!userRepository.existsById(user_id)) {
-            throw new NotFoundUser();
-        }
-
-        return postRepository.findByUserIdAndIsActive(user_id, true).stream()
-                .map(PostInfo::of)
-                .collect(Collectors.toList());
-    }
-
-    public PostInfoWithComment findByPostId(Long id) {
-        Post post = postRepository.findByPostIdAndIsActive(id, true);
-        return postMapper.mapPostEntityToPostInfoWithComment(post);
-
-    }
-
-    public List<PostInfo> findByWord(String word) {
-        return postRepository.findByWordAndIsActive(word, true)
-                .stream()
-                .map(PostInfo::of)
-                .collect(Collectors.toList());
-    }
+  public List<PostInfo> findByWord(String word) {
+    return postRepository.findByWordAndIsActive(word, true)
+        .stream()
+        .map(PostInfo::of)
+        .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package carrotTeam.carrot.domain.post.service;
 import carrotTeam.carrot.domain.post.domain.entity.Post;
 import carrotTeam.carrot.domain.post.domain.repository.PostRepository;
 import carrotTeam.carrot.domain.post.dto.PostInfo;
+import carrotTeam.carrot.domain.post.dto.PostInfoWithComment;
 import carrotTeam.carrot.domain.post.dto.PostRequest;
 import carrotTeam.carrot.domain.post.exception.NotFoundPost;
 import carrotTeam.carrot.domain.post.mapper.PostMapper;
@@ -102,10 +103,10 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
-    public List<PostInfo> findByPostId(Long id) {
-        return postRepository.findByPostIdAndIsActive(id, true).stream()
-                .map(PostInfo::of)
-                .collect(Collectors.toList());
+    public PostInfoWithComment findByPostId(Long id) {
+        Post post = postRepository.findByPostIdAndIsActive(id, true);
+        return postMapper.mapPostEntityToPostInfoWithComment(post);
+
     }
 
     public List<PostInfo> findByWord(String word) {

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -122,19 +122,19 @@ public class PostService {
       throw new NotFoundUser();
     }
 
-    return postRepository.findByUserIdAndIsActive(user_id, true).stream()
+    return postRepository.findByUserIdAndIsActive(user_id).stream()
         .map(PostInfo::of)
         .collect(Collectors.toList());
   }
 
   public PostInfoWithComment findByPostId(Long id) {
-    Post post = postRepository.findByPostIdAndIsActive(id, true);
+    Post post = postRepository.findByPostIdAndIsActive(id);
     return postMapper.mapPostEntityToPostInfoWithComment(post);
 
   }
 
   public List<PostInfo> findByWord(String word) {
-    return postRepository.findByWordAndIsActive(word, true)
+    return postRepository.findByWordAndIsActive(word)
         .stream()
         .map(PostInfo::of)
         .collect(Collectors.toList());

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -80,8 +80,15 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
-    public List<PostInfo> findById(Long id) {
-        return postRepository.findByIdAndIsActive(id, true)
+    public List<PostInfo> findByUserId(Long id) {
+        return postRepository.findByUserIdAndIsActive(id, true)
+                .stream()
+                .map(PostInfo::of)
+                .collect(Collectors.toList());
+    }
+
+    public List<PostInfo> findByPostId(Long id) {
+        return postRepository.findByPostIdAndIsActive(id, true)
                 .stream()
                 .map(PostInfo::of)
                 .collect(Collectors.toList());

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -42,7 +42,7 @@ public class PostService {
 
   private final AmazonS3 amazonS3;
 
-  public String upload(MultipartFile multipartFile)  {
+  public String upload(MultipartFile multipartFile) {
     // 파일 이름 중복 X -> UUID 로 생성한 랜덤 값에 파일이름 연결
     String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
 
@@ -55,7 +55,7 @@ public class PostService {
       // S3 API 메소드인 putObject 사용하여 파일 Stream 을 열어서 S3에 파일을 업로드
       amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
     } catch (IOException e) {
-      throw  new NotUploadPost();
+      throw new NotUploadPost();
     }
 
     // getUrl 메소드를 통해서 S3에 업로드된 사진 URL을 가져오는 방식
@@ -80,7 +80,8 @@ public class PostService {
     return postMapper.mapPostEntityToPostInfo(post);
   }
 
-  public PostInfo updatePost(Long user_id, Long post_id, String title, String content, List<String> address_list) {
+  public PostInfo updatePost(Long user_id, Long post_id, String title, String content,
+      List<String> address_list) {
 
     Post post = postRepository.findById(post_id).orElseThrow(NotFoundPost::new);
 

--- a/src/main/java/carrotTeam/carrot/global/error/ErrorCode.java
+++ b/src/main/java/carrotTeam/carrot/global/error/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     // Post
     POST_NOT_FOUND(400, "P001","게시글이 존재하지 않습니다!"),
+    POST_NOT_UPLOAD(400, "P002","게시글이 업로드에 실패하였습니다!"),
 
     // Comment
     COMMENT_NOT_FOUND(400,"C001","댓글이 존재하지 않습니다!")

--- a/src/main/java/carrotTeam/carrot/global/error/ErrorCode.java
+++ b/src/main/java/carrotTeam/carrot/global/error/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     // Post
     POST_NOT_FOUND(400, "P001","게시글이 존재하지 않습니다!"),
     POST_NOT_UPLOAD(400, "P002","게시글이 업로드에 실패하였습니다!"),
+    POST_NOT_UPDATE(400, "P003","게시글 변경은 제작한 유저만 가능합니다!"),
 
     // Comment
     COMMENT_NOT_FOUND(400,"C001","댓글이 존재하지 않습니다!")

--- a/src/main/java/carrotTeam/carrot/global/result/ResultCode.java
+++ b/src/main/java/carrotTeam/carrot/global/result/ResultCode.java
@@ -12,16 +12,15 @@ public enum ResultCode {
     // user
 
     // post
-
+    CREATE_POST_SUCCESS("C004", "200", "게시글이 등록되었습니다"),
+    UPDATE_POST_SUCCESS("C005", "200", "게시글이 수정되었습니다"),
+    DELETE_POST_SUCCESS("C006","200","게시글을 삭제하였습니다!"),
+    GET_ALL_POST_SUCCESS("C007", "200", "전체 게시글을 조회하였습니다!"),
+    GET_USER_POST_SUCCESS("C008", "200", "유저 게시글을 조회하였습니다!"),
     // comment
     CREATE_COMMENT_SUCCESS("C001", "200", "댓글이 등록되었습니다!"),
     GET_ONE_POST_COMMENT_SUCCESS("C002", "200", "게시글의 댓글을 조회하였습니다!"),
     DELETE_COMMENT_SUCCESS("C003","200","게시글의 댓글을 삭제하였습니다!"),
-    CREATE_POST_SUCCESS("c004", "200", "게시글이 등록되었습니다"),
-    UPDATE_POST_SUCCESS("c005", "200", "게시글이 수정되었습니다"),
-    DELETE_POST_SUCCESS("C006","200","게시글을 삭제하였습니다!"),
-    GET_ALL_POST_SUCCESS("C007", "200", "전체 게시글을 조회하였습니다!"),
-    GET_USER_POST_SUCCESS("C008", "200", "유저 게시글을 조회하였습니다!"),
     ;
 
     private final String code;

--- a/src/main/java/carrotTeam/carrot/global/result/ResultCode.java
+++ b/src/main/java/carrotTeam/carrot/global/result/ResultCode.java
@@ -17,6 +17,11 @@ public enum ResultCode {
     CREATE_COMMENT_SUCCESS("C001", "200", "댓글이 등록되었습니다!"),
     GET_ONE_POST_COMMENT_SUCCESS("C002", "200", "게시글의 댓글을 조회하였습니다!"),
     DELETE_COMMENT_SUCCESS("C003","200","게시글의 댓글을 삭제하였습니다!"),
+    CREATE_POST_SUCCESS("c004", "200", "게시글이 등록되었습니다"),
+    UPDATE_POST_SUCCESS("c005", "200", "게시글이 수정되었습니다"),
+    DELETE_POST_SUCCESS("C006","200","게시글을 삭제하였습니다!"),
+    GET_ALL_POST_SUCCESS("C007", "200", "전체 게시글을 조회하였습니다!"),
+    GET_USER_POST_SUCCESS("C008", "200", "유저 게시글을 조회하였습니다!"),
     ;
 
     private final String code;


### PR DESCRIPTION
1. N+1 : FetchType.LAZY를 사용하여 해결
2. post api 주소 : @RequestMapping("/api/posts") 이후 각 기능에 맞게 맵핑
3. 이미지 업로드 (여러개) : List<MultipartFile> 사용하여 여러갸의 파일 업로드 가능
4. 게시글 조회시 댓글까지 반환
    → @OneToMany로 연관관계 지정 후 PostInfoWithComment DTO로 형탸로 제작하여 반환
    → 최신 댓글 순으로 3개만 반환 (`PostMapper`에 구현)
5. 게시글 삭제시 연관 댓글까지 삭제
6. 예외처리 추가
7. 구글 스타일 포멧