### PR TITLE
[feat] 대댓글 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,39 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
+
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.9'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
-	id 'com.google.cloud.tools.jib' version '3.2.1'
-	id 'jacoco'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.9'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'com.google.cloud.tools.jib' version '3.2.1'
+    id 'jacoco'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+
 }
 
 jib {
-	from {
-		image = "openjdk:11-jre-slim"
-		auth {
-			username = project.DOCKER_ID
-			password = project.DOCKER_PASSWORD
-		}
-	}
-	to {
-		image = project.DOCKER_ID + "/" + project.DOCKER_IMAGE_NAME
-		auth {
-			username = project.DOCKER_ID
-			password = project.DOCKER_PASSWORD
-		}
-		tags = ["latest"]
-	}
-	container {
-		jvmFlags = ["-Xms128m", "-Xmx128m"]
-	}
+    from {
+        image = "openjdk:11-jre-slim"
+        auth {
+            username = project.DOCKER_ID
+            password = project.DOCKER_PASSWORD
+        }
+    }
+    to {
+        image = project.DOCKER_ID + "/" + project.DOCKER_IMAGE_NAME
+        auth {
+            username = project.DOCKER_ID
+            password = project.DOCKER_PASSWORD
+        }
+        tags = ["latest"]
+    }
+    container {
+        jvmFlags = ["-Xms128m", "-Xmx128m"]
+    }
 }
 
 group = 'com.example'
@@ -36,27 +45,51 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
+    //querydsl 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
+//querydsl 추가 시작
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+//querydsl 추가 끝

--- a/src/main/java/carrotTeam/carrot/domain/comment/controller/CommentController.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/controller/CommentController.java
@@ -3,42 +3,48 @@ package carrotTeam.carrot.domain.comment.controller;
 import carrotTeam.carrot.domain.comment.dto.CommentInfo;
 import carrotTeam.carrot.domain.comment.dto.CommentRequest;
 import carrotTeam.carrot.domain.comment.dto.CommentResponse;
+import carrotTeam.carrot.domain.comment.service.CommentService;
 import carrotTeam.carrot.global.result.ResultCode;
 import carrotTeam.carrot.global.result.ResultResponse;
-import org.springframework.web.bind.annotation.*;
-import carrotTeam.carrot.domain.comment.service.CommentService;
+import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-
-import javax.validation.Valid;
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 public class CommentController {
 
-    private final CommentService commentService;
+  private final CommentService commentService;
 
-    @PostMapping("/api/comments")
-    public ResponseEntity<ResultResponse> createComment(@Valid @RequestBody CommentRequest commentRequest) {
+  @PostMapping("/api/comments")
+  public ResponseEntity<ResultResponse> createComment(
+      @Valid @RequestBody CommentRequest commentRequest) {
 
-        CommentInfo commentInfo = commentService.createComment(commentRequest);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.CREATE_COMMENT_SUCCESS, commentInfo));
-    }
+    CommentInfo commentInfo = commentService.createComment(commentRequest);
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.CREATE_COMMENT_SUCCESS, commentInfo));
+  }
 
-    @GetMapping("/api/comments/{post_id}")
-    public ResponseEntity<ResultResponse> getCommentList(@PathVariable Long post_id) {
+  @GetMapping("/api/comments/{post_id}")
+  public ResponseEntity<ResultResponse> getCommentList(@PathVariable Long post_id) {
 
-        List<CommentResponse> commentList = commentService.findCommentByPostId(post_id);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_ONE_POST_COMMENT_SUCCESS, commentList));
-    }
+    List<CommentResponse> commentList = commentService.findCommentByPostId(post_id);
+    return ResponseEntity.ok(
+        ResultResponse.of(ResultCode.GET_ONE_POST_COMMENT_SUCCESS, commentList));
+  }
 
-    @DeleteMapping("/api/comments/{comment_id}")
-    public ResponseEntity<ResultResponse> deleteComment( @PathVariable Long comment_id ){
+  @DeleteMapping("/api/comments/{comment_id}")
+  public ResponseEntity<ResultResponse> deleteComment(@PathVariable Long comment_id) {
 
-        commentService.deleteComment(comment_id);
-        return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_COMMENT_SUCCESS));
-    }
+    commentService.deleteComment(comment_id);
+    return ResponseEntity.ok(ResultResponse.of(ResultCode.DELETE_COMMENT_SUCCESS));
+  }
 
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
@@ -3,14 +3,19 @@ package carrotTeam.carrot.domain.comment.domain.entity;
 import carrotTeam.carrot.domain.post.domain.entity.Post;
 import carrotTeam.carrot.domain.user.domain.entity.User;
 import carrotTeam.carrot.global.common.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import javax.persistence.*;
-import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,8 +45,6 @@ public class Comment extends BaseEntity {
   @JoinColumn(name = "parent_id")
   private Comment parentComment;
 
-//    @OneToMany(mappedBy = "parentComment",)
-//    private List<Comment> childrenComment = new ArrayList<>();
 
   @Builder
   private Comment(String content, Post post, User user) {

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
@@ -1,4 +1,5 @@
 package carrotTeam.carrot.domain.comment.domain.entity;
+
 import carrotTeam.carrot.domain.post.domain.entity.Post;
 import carrotTeam.carrot.domain.user.domain.entity.User;
 import carrotTeam.carrot.global.common.BaseEntity;
@@ -8,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,29 +19,35 @@ import javax.validation.constraints.NotNull;
 public class Comment extends BaseEntity {
 
 
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "comment_id", nullable = false)
+  private Long id;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id", nullable = false)
-    private Long id;
 
+  @Column(name = "content", length = 100, nullable = false)
+  private String content;
 
-    @Column(name = "content", length = 100, nullable = false)
-    private String content;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
-    private Post post;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private Comment parentComment;
 
-    @Builder
-    private Comment(String content, Post post, User user) {
-        this.content = content;
-        this.post = post;
-        this.user = user;
-    }
+//    @OneToMany(mappedBy = "parentComment",)
+//    private List<Comment> childrenComment = new ArrayList<>();
+
+  @Builder
+  private Comment(String content, Post post, User user) {
+    this.content = content;
+    this.post = post;
+    this.user = user;
+  }
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
@@ -3,6 +3,8 @@ package carrotTeam.carrot.domain.comment.domain.entity;
 import carrotTeam.carrot.domain.post.domain.entity.Post;
 import carrotTeam.carrot.domain.user.domain.entity.User;
 import carrotTeam.carrot.global.common.BaseEntity;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -11,6 +13,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -45,6 +48,8 @@ public class Comment extends BaseEntity {
   @JoinColumn(name = "parent_id")
   private Comment parentComment;
 
+  @OneToMany(mappedBy = "parentComment", orphanRemoval = true)
+  private List<Comment> childrenComment = new ArrayList<>();
 
   @Builder
   private Comment(String content, Post post, User user) {

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
@@ -52,10 +52,11 @@ public class Comment extends BaseEntity {
   private List<Comment> childrenComment = new ArrayList<>();
 
   @Builder
-  private Comment(String content, Post post, User user) {
+  private Comment(String content, Post post, User user, Comment parentComment) {
     this.content = content;
     this.post = post;
     this.user = user;
+    this.parentComment = parentComment;
   }
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/entity/Comment.java
@@ -26,12 +26,10 @@ public class Comment extends BaseEntity {
     @Column(name = "content", length = 100, nullable = false)
     private String content;
 
-//    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-//    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/CommentRepository.java
@@ -1,14 +1,12 @@
 package carrotTeam.carrot.domain.comment.domain.repository;
 
 import carrotTeam.carrot.domain.comment.domain.entity.Comment;
-import java.util.List;
+import carrotTeam.carrot.domain.comment.domain.repository.querydsl.CommentRepositoryQuerydsl;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryQuerydsl {
 
-  @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.isActive = true AND c.post.id=:id")
-  List<Comment> findByPostId(@Param("id") Long id);
+//  @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.isActive = true AND c.post.id=:id")
+//  List<Comment> findByPostId(@Param("id") Long id);
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/CommentRepository.java
@@ -1,15 +1,14 @@
 package carrotTeam.carrot.domain.comment.domain.repository;
 
 import carrotTeam.carrot.domain.comment.domain.entity.Comment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.isActive = true AND c.post.id=:id")
-    List<Comment> findByPostId(@Param("id") Long id);
+  @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.isActive = true AND c.post.id=:id")
+  List<Comment> findByPostId(@Param("id") Long id);
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/querydsl/CommentRepositoryQuerydsl.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/querydsl/CommentRepositoryQuerydsl.java
@@ -1,0 +1,11 @@
+package carrotTeam.carrot.domain.comment.domain.repository.querydsl;
+
+import carrotTeam.carrot.domain.comment.domain.entity.Comment;
+import java.util.List;
+
+public interface CommentRepositoryQuerydsl {
+
+  List<Comment> findByPostId(Long postId);
+
+
+}

--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/querydsl/CommentRepositoryQuerydslImpl.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/querydsl/CommentRepositoryQuerydslImpl.java
@@ -1,0 +1,33 @@
+package carrotTeam.carrot.domain.comment.domain.repository.querydsl;
+
+import static carrotTeam.carrot.domain.comment.domain.entity.QComment.comment;
+
+import carrotTeam.carrot.domain.comment.domain.entity.Comment;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CommentRepositoryQuerydslImpl implements CommentRepositoryQuerydsl {
+
+  private final JPAQueryFactory queryFactory;
+
+  //1. parent_id가 null이면 최상위댓글이므로 오름차순
+  //2. createdAt을 오름차순으로
+  @Override
+  public List<Comment> findByPostId(Long postId) {
+
+    return queryFactory
+        .select(comment)
+        .from(comment)
+        .leftJoin(comment.parentComment)
+        .where(comment.post.id.eq(postId))
+        .orderBy(
+            comment.parentComment.id.asc().nullsFirst(),
+            comment.createdAt.asc())
+        .fetch();
+
+  }
+
+
+}

--- a/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentInfo.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentInfo.java
@@ -1,20 +1,20 @@
 package carrotTeam.carrot.domain.comment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
 
 @Getter
 @NoArgsConstructor
 public class CommentInfo {
 
-  @DateTimeFormat
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
   private LocalDateTime createAt;
 
-  @DateTimeFormat
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
   private LocalDateTime updateAt;
 
   private String content;

--- a/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentInfo.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentInfo.java
@@ -11,19 +11,19 @@ import org.springframework.format.annotation.DateTimeFormat;
 @NoArgsConstructor
 public class CommentInfo {
 
-    @DateTimeFormat
-    private LocalDateTime createAt;
+  @DateTimeFormat
+  private LocalDateTime createAt;
 
-    @DateTimeFormat
-    private LocalDateTime updateAt;
+  @DateTimeFormat
+  private LocalDateTime updateAt;
 
-    private  String content;
+  private String content;
 
-    @Builder
-    public CommentInfo(String content, LocalDateTime createAt, LocalDateTime updateAt) {
-        this.content = content;
-        this.createAt = createAt;
-        this.updateAt = updateAt;
-    }
+  @Builder
+  public CommentInfo(String content, LocalDateTime createAt, LocalDateTime updateAt) {
+    this.content = content;
+    this.createAt = createAt;
+    this.updateAt = updateAt;
+  }
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentRequest.java
@@ -23,6 +23,9 @@ public class CommentRequest {
   @Schema(description = "post 아이디")
   private Long post_id;
 
+  @Schema(description = "parent_comment 아이디")
+  private Long parent_id;
+
   @Schema(description = "comment 내용")
   @NotBlank(message = "댓글을 작성해주세요!")
   private String content;

--- a/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentRequest.java
@@ -1,12 +1,13 @@
 package carrotTeam.carrot.domain.comment.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
-
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -14,17 +15,17 @@ import java.time.format.DateTimeFormatter;
 @Getter
 public class CommentRequest {
 
-    @NotNull
-    @Schema(description = "user 아이디")
-    private Long user_id;
+  @NotNull
+  @Schema(description = "user 아이디")
+  private Long user_id;
 
-    @NotNull
-    @Schema(description = "post 아이디")
-    private Long post_id;
+  @NotNull
+  @Schema(description = "post 아이디")
+  private Long post_id;
 
-    @Schema(description = "comment 내용")
-    @NotBlank(message = "댓글을 작성해주세요!")
-    private String content;
+  @Schema(description = "comment 내용")
+  @NotBlank(message = "댓글을 작성해주세요!")
+  private String content;
 
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentResponse.java
@@ -1,19 +1,18 @@
 package carrotTeam.carrot.domain.comment.dto;
-import carrotTeam.carrot.domain.comment.domain.entity.Comment;
-import carrotTeam.carrot.domain.post.dto.PostInfo;
+
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class CommentResponse {
 
-    private Long comment_Id;
-    private String nickName;
-    private String content;
-    private LocalDateTime localDateTime;
+  private Long comment_Id;
+  private String nickName;
+  private String content;
+  private LocalDateTime localDateTime;
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentResponse.java
@@ -20,6 +20,12 @@ public class CommentResponse {
   private LocalDateTime createAt;
   private List<CommentResponse> childrenComment = new ArrayList<>();
 
+  public List<CommentResponse> getChildrenComment() {
+    if (childrenComment == null) {
+      childrenComment = new ArrayList<>();
+    }
+    return childrenComment;
+  }
 
 }
 

--- a/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentResponse.java
@@ -1,10 +1,14 @@
 package carrotTeam.carrot.domain.comment.dto;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 @Builder
 @AllArgsConstructor
@@ -13,6 +17,9 @@ public class CommentResponse {
   private Long comment_Id;
   private String nickName;
   private String content;
-  private LocalDateTime localDateTime;
+  private LocalDateTime createAt;
+  private List<CommentResponse> childrenComment = new ArrayList<>();
+
 
 }
+

--- a/src/main/java/carrotTeam/carrot/domain/comment/exception/NotFoundComment.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/exception/NotFoundComment.java
@@ -2,8 +2,10 @@ package carrotTeam.carrot.domain.comment.exception;
 
 import carrotTeam.carrot.global.error.ErrorCode;
 import carrotTeam.carrot.global.error.exception.BusinessException;
-import net.bytebuddy.implementation.bind.annotation.Super;
 
 public class NotFoundComment extends BusinessException {
-    public NotFoundComment(){ super(ErrorCode.COMMENT_NOT_FOUND);}
+
+  public NotFoundComment() {
+    super(ErrorCode.COMMENT_NOT_FOUND);
+  }
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/mapper/CommentMapper.java
@@ -2,21 +2,17 @@ package carrotTeam.carrot.domain.comment.mapper;
 
 import carrotTeam.carrot.domain.comment.domain.entity.Comment;
 import carrotTeam.carrot.domain.comment.dto.CommentInfo;
-import carrotTeam.carrot.domain.comment.dto.CommentRequest;
-import carrotTeam.carrot.domain.post.domain.entity.Post;
-import carrotTeam.carrot.domain.user.domain.entity.User;
-import carrotTeam.carrot.domain.user.service.UserService;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CommentMapper {
 
-    public CommentInfo mapCommentEntityToCommentInfo(Comment Comment) {
-        return CommentInfo.builder()
-                .content(Comment.getContent())
-                .createAt(Comment.getCreatedAt())
-                .updateAt(Comment.getUpdatedAt())
-                .build();
-    }
+  public CommentInfo mapCommentEntityToCommentInfo(Comment Comment) {
+    return CommentInfo.builder()
+        .content(Comment.getContent())
+        .createAt(Comment.getCreatedAt())
+        .updateAt(Comment.getUpdatedAt())
+        .build();
+  }
 
 }

--- a/src/main/java/carrotTeam/carrot/domain/comment/service/CommentService.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/service/CommentService.java
@@ -42,10 +42,17 @@ public class CommentService {
     User findUser = getUserById(commentRequest.getUser_id());
     Post findPost = getPostById(commentRequest.getPost_id());
 
+    Comment findParent = null;
+    if (commentRequest.getParent_id() != null) {
+      findParent = commentRepository.findById(commentRequest.getParent_id())
+          .orElseThrow(NotFoundComment::new);
+    }
+
     return Comment.builder()
         .user(findUser)
         .post(findPost)
         .content(commentRequest.getContent())
+        .parentComment(findParent)
         .build();
   }
 

--- a/src/main/java/carrotTeam/carrot/domain/comment/service/CommentService.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/service/CommentService.java
@@ -13,91 +13,89 @@ import carrotTeam.carrot.domain.post.exception.NotFoundPost;
 import carrotTeam.carrot.domain.user.domain.entity.User;
 import carrotTeam.carrot.domain.user.domain.repositorty.UserRepository;
 import carrotTeam.carrot.domain.user.exception.NotFoundUser;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class CommentService {
 
 
-    private final CommentRepository commentRepository;
-    private final UserRepository userRepository;
-    private final PostRepository postRepository;
-    private final CommentMapper commentMapper;
+  private final CommentRepository commentRepository;
+  private final UserRepository userRepository;
+  private final PostRepository postRepository;
+  private final CommentMapper commentMapper;
 
 
-    public CommentInfo createComment(CommentRequest commentRequest) {
+  public CommentInfo createComment(CommentRequest commentRequest) {
 
-        Comment newComment = createCommentToEntity(commentRequest);
-        Comment savedComment = commentRepository.save(newComment);
-        return commentMapper.mapCommentEntityToCommentInfo(savedComment);
+    Comment newComment = createCommentToEntity(commentRequest);
+    Comment savedComment = commentRepository.save(newComment);
+    return commentMapper.mapCommentEntityToCommentInfo(savedComment);
+  }
+
+  public Comment createCommentToEntity(CommentRequest commentRequest) {
+
+    User findUser = getUserById(commentRequest.getUser_id());
+    Post findPost = getPostById(commentRequest.getPost_id());
+
+    return Comment.builder()
+        .user(findUser)
+        .post(findPost)
+        .content(commentRequest.getContent())
+        .build();
+  }
+
+  public List<CommentResponse> findCommentByPostId(Long id) {
+
+    if (!postRepository.existsById(id)) {
+      throw new NotFoundPost();
     }
+    List<CommentResponse> commentList =
+        commentRepository.findByPostId(id).stream()
+            .map(this::commentEntityToCommentResponse)
+            .collect(Collectors.toList());
+    return commentList;
+  }
 
-    public Comment createCommentToEntity(CommentRequest commentRequest) {
+  private CommentResponse commentEntityToCommentResponse(Comment comment) {
+    return CommentResponse.builder()
+        .comment_Id(comment.getId())
+        .content(comment.getContent())
+        .nickName(comment.getUser().getNickname())
+        .localDateTime(comment.getCreatedAt())
+        .build();
+  }
 
-        User findUser = getUserById(commentRequest.getUser_id());
-        Post findPost = getPostById(commentRequest.getPost_id());
+  @Transactional
+  public void deleteComment(Long comment_id) {
 
-        return Comment.builder()
-                .user(findUser)
-                .post(findPost)
-                .content(commentRequest.getContent())
-                .build();
+    Comment foundComment = commentRepository.findById(comment_id).orElseThrow(NotFoundComment::new);
+    if (!foundComment.getIsActive()) {
+      throw new NotFoundComment();
     }
-
-    public List<CommentResponse> findCommentByPostId(Long id){
-
-        if(!postRepository.existsById(id)){
-            throw new NotFoundPost();
-        }
-        List<CommentResponse> commentList =
-                commentRepository.findByPostId(id).stream()
-                        .map(this::commentEntityToCommentResponse)
-                        .collect(Collectors.toList());
-        return commentList;
-    }
-
-    private CommentResponse commentEntityToCommentResponse(Comment comment) {
-        return CommentResponse.builder()
-                .comment_Id(comment.getId())
-                .content(comment.getContent())
-                .nickName(comment.getUser().getNickname())
-                .localDateTime(comment.getCreatedAt())
-                .build();
-    }
-
-    @Transactional
-    public void deleteComment(Long comment_id){
-
-        Comment foundComment = commentRepository.findById(comment_id).orElseThrow(NotFoundComment::new);
-        if(!foundComment.getIsActive()){
-            throw new NotFoundComment();
-        }
-        foundComment.delete();
-        commentRepository.save(foundComment);
-    }
+    foundComment.delete();
+    commentRepository.save(foundComment);
+  }
 
 
+  private User getUserById(Long userId) {
 
-    private User getUserById(Long userId) {
+    return userRepository.findById(userId).orElseThrow(NotFoundUser::new);
+  }
 
-        return userRepository.findById(userId).orElseThrow(NotFoundUser::new);
-    }
+  private Post getPostById(Long postId) {
 
-    private Post getPostById(Long postId) {
+    return postRepository.findById(postId).orElseThrow(NotFoundPost::new);
+  }
 
-        return postRepository.findById(postId).orElseThrow(NotFoundPost::new);
-    }
+  private Comment getCommentById(Long commentId) {
 
-    private Comment getCommentById(Long commentId){
-
-        return commentRepository.findById(commentId).orElseThrow(NotFoundComment::new);
-    }
+    return commentRepository.findById(commentId).orElseThrow(NotFoundComment::new);
+  }
 }
 
 

--- a/src/main/java/carrotTeam/carrot/global/config/QueryDslConfig.java
+++ b/src/main/java/carrotTeam/carrot/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package carrotTeam.carrot.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+
+}


### PR DESCRIPTION
1. 복잡한 검색조건을 QueryDSL로 구현 -> build.gradle 세팅
-> 연관관계가 있는 User의 쿼리가 N번 나가는 N+1 이슈 해결 예정

2. parent_id가 null인 경우(최상위 댓글)에는 CommentList에 Add가 되고,  parent_id 가 null이 아닌 경우(자식댓글)에는 부모 댓글의 children 리스트에 현재 댓글(commeentResponse)을 추가하는 방식으로 구현함