### PR TITLE
Feat/#25 조회수 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/carrotTeam/carrot/domain/post/RedisConfig.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/RedisConfig.java
@@ -1,0 +1,49 @@
+package carrotTeam.carrot.domain.post;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig extends CachingConfigurerSupport {
+
+  @Value("${spring.redis.host}")
+  private String host;
+
+  @Value("${spring.redis.port}")
+  private int port;
+
+  @Bean
+  public LettuceConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(
+        host, port);
+    return new LettuceConnectionFactory(host, port);
+  }
+
+
+  @Bean
+  public RedisTemplate<?, ?> redisTemplate() {
+    RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    return redisTemplate;
+  }
+
+  @Bean
+  public CacheManager cacheManager() {
+    RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(Duration.ofSeconds(60)); // 60초 만료시간으로 설정
+    return RedisCacheManager.builder(redisConnectionFactory())
+        .cacheDefaults(cacheConfig)
+        .build();
+  }
+}
+

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -54,7 +54,8 @@ public class PostController {
       address_list.add(picture_address);
     }
 
-    PostInfo postInfo = service.updatePost(postUpdateRequest.getUser_id(), postUpdateRequest.getPost_id(),
+    PostInfo postInfo = service.updatePost(postUpdateRequest.getUser_id(),
+        postUpdateRequest.getPost_id(),
         postUpdateRequest.getTitle(),
         postUpdateRequest.getContent(), address_list);
     return ResponseEntity.ok(ResultResponse.of(ResultCode.UPDATE_POST_SUCCESS, postInfo));

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -57,7 +57,7 @@ public class Post extends BaseEntity {
     this.picture_address = picture_address;
   }
 
-  public void updateView (Long viewCount) {
+  public void updateView(Long viewCount) {
     this.view += viewCount;
   }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -27,6 +27,9 @@ public class Post extends BaseEntity {
   @Column(name = "content", nullable = false, length = 500)
   private String content;
 
+  @Column(name = "view", nullable = false)
+  private int view;
+
   @Column(name = "picture_address", nullable = false, length = 2000)
   @ElementCollection
   private List<String> picture_address;
@@ -52,5 +55,9 @@ public class Post extends BaseEntity {
     this.title = title;
     this.content = content;
     this.picture_address = picture_address;
+  }
+
+  public void updateView (Long viewCount) {
+    this.view += viewCount;
   }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/RedisPost.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/RedisPost.java
@@ -1,0 +1,30 @@
+package carrotTeam.carrot.domain.post.domain.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@RedisHash("post")
+public class RedisPost implements Serializable {
+
+  @Id
+  private Long id;
+  private Long viewCount;
+
+  public RedisPost() {
+    this.viewCount = 0L;
+  }
+
+  public void increaseViewCount() {
+    this.viewCount++;
+  }
+
+  public void cleanViewCount() {
+    this.viewCount = 0L;
+  }
+}

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/repository/RedisRepository.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/repository/RedisRepository.java
@@ -1,0 +1,9 @@
+package carrotTeam.carrot.domain.post.domain.repository;
+
+import carrotTeam.carrot.domain.post.domain.entity.RedisPost;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RedisRepository extends CrudRepository<RedisPost, String> {
+}

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/repository/RedisRepository.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/repository/RedisRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RedisRepository extends CrudRepository<RedisPost, String> {
+
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/service/RedisScheduled.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/RedisScheduled.java
@@ -23,8 +23,8 @@ public class RedisScheduled {
   private final RedisTemplate<String, RedisPost> redisTemplate;
   @Scheduled(fixedDelay = 10000) //10초마다 실행
   public void flushViews() {
-    System.out.println("조회수 스케쥴러 실행 중 !!!");
-줌
+    System.out.println("조회수 스케쥴러 실행 중 !!!"); //이후 log로 변경 예정
+
     Set<String> keys = redisTemplate.keys("*");
     Map<String, Object> redisHash = new HashMap<>();
 
@@ -50,5 +50,11 @@ public class RedisScheduled {
       post.updateView(redisPost.getViewCount());
       postRepository.save(post);
     });
+  }
+
+  @Scheduled(fixedRate = 50000) //50초마다 실향
+  public void cleanupRedisMemory() {
+    redisTemplate.getConnectionFactory().getConnection().flushAll();
+    System.out.println("레디스 메모리 초기화 진행 중 !!!"); //이후 log로 변경 예정
   }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/service/RedisScheduled.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/RedisScheduled.java
@@ -1,0 +1,54 @@
+package carrotTeam.carrot.domain.post.service;
+
+import carrotTeam.carrot.domain.post.domain.entity.Post;
+import carrotTeam.carrot.domain.post.domain.entity.RedisPost;
+import carrotTeam.carrot.domain.post.domain.repository.PostRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class RedisScheduled {
+  private final PostRepository postRepository;
+  private final RedisTemplate<String, RedisPost> redisTemplate;
+  @Scheduled(fixedDelay = 10000) //10초마다 실행
+  public void flushViews() {
+    System.out.println("조회수 스케쥴러 실행 중 !!!");
+줌
+    Set<String> keys = redisTemplate.keys("*");
+    Map<String, Object> redisHash = new HashMap<>();
+
+    for (String s : keys) {
+      redisHash.put(s, redisTemplate.opsForValue().get(s));
+    }
+
+    //  레디스에서 조회수 변경이 있는 id만 찾아서 리스트로 제작
+    List<RedisPost> redisPosts = redisHash.values().stream()
+        .map(obj -> (RedisPost) obj)
+        .filter(redisPost -> redisPost.getViewCount() != 0)
+        .collect(Collectors.toList());
+
+    for (Object key : keys) {
+      RedisPost redisPost = redisTemplate.opsForValue().get(key.toString());
+      redisPost.cleanViewCount();
+      redisTemplate.opsForValue().set(key.toString(), redisPost);
+    }
+
+    redisPosts.forEach(redisPost -> {
+      Post post = postRepository.findById(redisPost.getId())
+          .orElseThrow(() -> new IllegalArgumentException("Post not found for id " + redisPost.getId()));
+      post.updateView(redisPost.getViewCount());
+      postRepository.save(post);
+    });
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  redis:
+    host: localhost
+    port: 6379
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
레디스를 캐시로 사용하여 구현하였습니다.
- 조회수 로직
1. post_id로 게시글을 조회시 redis에 post_id와 viewCount값을 +1씩 늘려줍니다. (PostService.increaseView( ) 부분)
2. spring의 스케줄러를 통해 RedisScheduled.flushViews( ) fixedDelay의 값의 초마다 redis에 있는 viewCount값이 0이 아닌 경우만 mysql의 view값을 update 합니다.
3. RedisScheduled.cleanupRedisMemory( ) fixedDelay의 값의 초마다 redis의 모든 데이터 지우는 코드 입니다. 지우지 않으면 redis에 key 값이 계속 쌓이기 때문에 초기화를 해줘야 합니다. 

비슷한 원리를 사용하여 좋아요 기능도 구현 예정입니다.