### PR TITLE
[refactor] 대댓글 조회 시 N+1 문제 해결

### DIFF
--- a/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/querydsl/CommentRepositoryQuerydslImpl.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/domain/repository/querydsl/CommentRepositoryQuerydslImpl.java
@@ -21,6 +21,7 @@ public class CommentRepositoryQuerydslImpl implements CommentRepositoryQuerydsl 
         .select(comment)
         .from(comment)
         .leftJoin(comment.parentComment)
+        .leftJoin(comment.user).fetchJoin()
         .where(comment.post.id.eq(postId))
         .orderBy(
             comment.parentComment.id.asc().nullsFirst(),

--- a/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/carrotTeam/carrot/domain/comment/dto/CommentResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,8 +23,12 @@ public class CommentResponse {
   private List<CommentResponse> childrenComment = new ArrayList<>();
 
   public List<CommentResponse> getChildrenComment() {
-    return Optional.ofNullable(childrenComment).orElse(new ArrayList<>());
+    if (childrenComment == null) {
+      childrenComment = new ArrayList<>();
+    }
+    return childrenComment;
   }
+
 
 }
 


### PR DESCRIPTION
1. 대댓글 조회 시 하위 Entitiy인 User가 N번 조회되는 N+1 문제를 QueryDSL의 Fetch Join으로 해결

2. 댓글만 조회되는 에러 해결