### PR TITLE
Feat/#32 좋아요 기능 구현

### DIFF
--- a/src/main/java/carrotTeam/carrot/domain/post/RedisConfig.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/RedisConfig.java
@@ -36,14 +36,5 @@ public class RedisConfig extends CachingConfigurerSupport {
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     return redisTemplate;
   }
-
-  @Bean
-  public CacheManager cacheManager() {
-    RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-        .entryTtl(Duration.ofSeconds(60)); // 60초 만료시간으로 설정
-    return RedisCacheManager.builder(redisConnectionFactory())
-        .cacheDefaults(cacheConfig)
-        .build();
-  }
 }
 

--- a/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/controller/PostController.java
@@ -92,6 +92,13 @@ public class PostController {
     return service.findByPostId(id);
   }
 
+  @GetMapping("like/{id}")
+  public PostInfoWithComment upByPostIdPostLike(
+      @PathVariable Long id
+  ) {
+    return service.upByPostIdPostLike(id);
+  }
+
   @GetMapping("/word/{word}")
   public ResponseEntity<ResultResponse> findTotalRestaurant(
       @RequestParam String word

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -27,10 +27,10 @@ public class Post extends BaseEntity {
   @Column(name = "content", nullable = false, length = 500)
   private String content;
 
-  @Column(name = "view", nullable = false)
+  @Column(name = "view_count", nullable = false)
   private int viewCount;
 
-  @Column(name = "like", nullable = false)
+  @Column(name = "like_count", nullable = false)
   private int likeCount;
 
   @Column(name = "picture_address", nullable = false, length = 2000)

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/Post.java
@@ -28,7 +28,10 @@ public class Post extends BaseEntity {
   private String content;
 
   @Column(name = "view", nullable = false)
-  private int view;
+  private int viewCount;
+
+  @Column(name = "like", nullable = false)
+  private int likeCount;
 
   @Column(name = "picture_address", nullable = false, length = 2000)
   @ElementCollection
@@ -58,6 +61,10 @@ public class Post extends BaseEntity {
   }
 
   public void updateView(Long viewCount) {
-    this.view += viewCount;
+    this.viewCount += viewCount;
+  }
+
+  public void updateLike(Long likeCount) {
+    this.likeCount += likeCount;
   }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/domain/entity/RedisPost.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/domain/entity/RedisPost.java
@@ -15,16 +15,23 @@ public class RedisPost implements Serializable {
   @Id
   private Long id;
   private Long viewCount;
+  private Long likeCount;
 
   public RedisPost() {
     this.viewCount = 0L;
+    this.likeCount = 0L;
   }
 
   public void increaseViewCount() {
     this.viewCount++;
   }
 
-  public void cleanViewCount() {
+  public void increaseLikeCount() {
+    this.likeCount++;
+  }
+
+  public void cleanViewLikeCount() {
     this.viewCount = 0L;
+    this.likeCount = 0L;
   }
 }

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfo.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfo.java
@@ -1,6 +1,7 @@
 package carrotTeam.carrot.domain.post.dto;
 
 import carrotTeam.carrot.domain.post.domain.entity.Post;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +21,9 @@ public class PostInfo {
   private String content;
   private List<String> picture_address;
   private Boolean isActive;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
   private LocalDateTime createdAt;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
   private LocalDateTime updatedAt;
 
   public static PostInfo of(Post entity) {

--- a/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfoWithComment.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/dto/PostInfoWithComment.java
@@ -1,7 +1,6 @@
 package carrotTeam.carrot.domain.post.dto;
 
-import carrotTeam.carrot.domain.comment.domain.entity.Comment;
-import carrotTeam.carrot.domain.post.domain.entity.Post;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +20,9 @@ public class PostInfoWithComment {
   private String content;
   private List<String> picture_address;
   private Boolean isActive;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
   private LocalDateTime createdAt;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
   private LocalDateTime updatedAt;
   private List<String> comment;
 

--- a/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
+++ b/src/main/java/carrotTeam/carrot/domain/post/service/PostService.java
@@ -156,13 +156,6 @@ public class PostService {
 
   }
 
-  public List<PostInfo> findByWord(String word) {
-    return postRepository.findByWordAndIsActive(word)
-        .stream()
-        .map(PostInfo::of)
-        .collect(Collectors.toList());
-  }
-
   public void increaseView(Long id) {
     RedisPost redisPost = redisTemplate.opsForValue().get(id.toString());
     if (redisPost == null) {
@@ -172,4 +165,30 @@ public class PostService {
     redisPost.increaseViewCount();
     redisTemplate.opsForValue().set(id.toString(), redisPost);
   }
+
+  public List<PostInfo> findByWord(String word) {
+    return postRepository.findByWordAndIsActive(word)
+        .stream()
+        .map(PostInfo::of)
+        .collect(Collectors.toList());
+  }
+
+  public PostInfoWithComment upByPostIdPostLike(Long id) {
+    increaseLike(id);
+    Post post = postRepository.findByPostIdAndIsActive(id);
+    return postMapper.mapPostEntityToPostInfoWithComment(post);
+  }
+
+  public void increaseLike(Long id) {
+    RedisPost redisPost = redisTemplate.opsForValue().get(id.toString()) ;
+    if (redisPost == null) {
+      redisPost = new RedisPost();
+      redisPost.setId(id);
+    }
+    redisPost.increaseLikeCount();
+    redisTemplate.opsForValue().set(id.toString(), redisPost);
+  }
+
+
+
 }


### PR DESCRIPTION
기존의 조회수 기능과 동일한 방법으로 조회수 기능을 구현하였습니다.
Redis의 캐시 설정값이 먹지 않아서 수동으로 Scheduled를 통해 Redis자체를 초기화하는 방법으로 진행하였습니다.

- 로직 순서
1. 좋아요 api 호출 -> redis 내부에서 id와 likeCount을 +1 해줌
2. RedisScheduled.java의 flushViews의 fixedDelay 값마다 redis에 있는 id 중에 값이 0이 아닌 경우 RDB에 값을 업데이트